### PR TITLE
✨ feat(logging): add robust Serilog logging with parameter sanitization

### DIFF
--- a/ZtrTemplates.Configuration.Shared/UpdateOptions.cs
+++ b/ZtrTemplates.Configuration.Shared/UpdateOptions.cs
@@ -1,9 +1,8 @@
 // In ZtrTemplates.Configuration.Shared/UpdateOptions.cs
-namespace ZtrTemplates.Configuration.Shared
+namespace ZtrTemplates.Configuration.Shared;
+
+public class UpdateOptions
 {
-    public class UpdateOptions
-    {
-        // This property name directly corresponds to the JSON key "UpdateUrl"
-        public string? UpdateUrl { get; set; }
-    }
+    // This property name directly corresponds to the JSON key "UpdateUrl"
+    public string? UpdateUrl { get; set; }
 }

--- a/build/Build.ApplicationConfiguration.cs
+++ b/build/Build.ApplicationConfiguration.cs
@@ -11,9 +11,9 @@ public partial class Build
     readonly string UpdateBaseUrl = "https://frog02-20366.wykr.es";
 
     Target ConfigureAppSettings => _ => _
-        .DependsOn(Clean) 
+        .DependsOn(Clean)
         .TriggeredBy(Clean)
-        .Unlisted() 
+        .Unlisted()
         .Executes(() =>
         {
             Log.Information("Configuring appsettings.json for deployment...");
@@ -44,17 +44,15 @@ public partial class Build
                 rootNode = null;
             }
 
-
             rootNode ??= new JsonObject();
-
 
             if (rootNode[nameof(UpdateOptions)] is not JsonObject updateOptionsNode)
             {
                 updateOptionsNode = new JsonObject();
                 rootNode[nameof(UpdateOptions)] = updateOptionsNode;
             }
-            updateOptionsNode[nameof(UpdateOptions.UpdateUrl)] = updateUrl;
 
+            updateOptionsNode[nameof(UpdateOptions.UpdateUrl)] = updateUrl;
 
             var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(appSettingsPath, rootNode.ToJsonString(jsonOptions));

--- a/build/Build.GitHub.cs
+++ b/build/Build.GitHub.cs
@@ -1,16 +1,10 @@
-﻿using Nuke.Common.CI.GitHubActions;
+﻿using Nuke.Common;
+using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.GitVersion;
-using Nuke.Common;
-using Octokit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Nuke.Common.Utilities;
-using static System.Net.Mime.MediaTypeNames;
+using Octokit;
 using Octokit.Internal;
 using System.IO;
 

--- a/build/Build.Velopack.cs
+++ b/build/Build.Velopack.cs
@@ -3,11 +3,6 @@ using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
 using Renci.SshNet;
-using Serilog;
-using System.IO;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using ZtrTemplates.Configuration.Shared;
 
 partial class Build
 {
@@ -18,12 +13,11 @@ partial class Build
     [Parameter] readonly int SshPort = 10366;
     [Parameter] readonly string SshUser = "frog";
     [Parameter] readonly string SshServer = "frog02.mikr.us";
-    ConnectionInfo SshConnectionInfo => new ConnectionInfo(SshServer, port: SshPort, SshUser, new PrivateKeyAuthenticationMethod(SshUser, new PrivateKeyFile(SshPrivateKey)));
+    ConnectionInfo SshConnectionInfo => new(SshServer, port: SshPort, SshUser, new PrivateKeyAuthenticationMethod(SshUser, new PrivateKeyFile(SshPrivateKey)));
 
     [Parameter] readonly int MaxReleasesOnServer = 2;
     [Parameter] readonly string DirectoryForReleases = "releases";
     string Channel => $"{OperationSystem}-{SystemArchitecture}" + (GitVersion.PreReleaseLabel.IsNullOrWhiteSpace() ? "" : "-alpha");
-
 
     AbsolutePath SshPrivateKey = RootDirectory / "ztrtemplates";
 
@@ -58,7 +52,7 @@ partial class Build
             using var sshClient = new SshClient(SshConnectionInfo);
             sshClient.Connect();
             using var cmd = sshClient.RunCommand($"mkdir -p /var/www/html/{NameProjectDirectoryOnTheServer}/{DirectoryForReleases}");
-            
+
             VelopackReleaseMirroredFromRemoteServer.CreateOrCleanDirectory();
             Scp.Invoke(
                 $"-i {SshPrivateKey} -r -P {SshPort} {SshUser}@{SshServer}:/var/www/html/{NameProjectDirectoryOnTheServer}/{DirectoryForReleases} {VelopackReleaseMirroredFromRemoteServer}");

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,17 +1,13 @@
 using Nuke.Common;
-using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.Git;
-using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.GitVersion;
-using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
-using System.IO;
 
 public partial class Build : NukeBuild
 {
@@ -31,7 +27,6 @@ public partial class Build : NukeBuild
 
     [Parameter("System architecture to build, deafults to current architecture. Change if you want to cross compile")]
     readonly SystemArchitecture SystemArchitecture = SystemArchitecture.GetCurrentConfiguration();
-
 
     string Runtime => $"{OperationSystem}-{SystemArchitecture}";
 

--- a/build/Parameters/Configuration.cs
+++ b/build/Parameters/Configuration.cs
@@ -1,6 +1,5 @@
-using System.ComponentModel;
-using System.Linq;
 using Nuke.Common.Tooling;
+using System.ComponentModel;
 
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration

--- a/build/Parameters/OperationSystem.cs
+++ b/build/Parameters/OperationSystem.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.ComponentModel;
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.Tooling;
+using System;
+using System.ComponentModel;
 
 [TypeConverter(typeof(TypeConverter<OperationSystem>))]
 public class OperationSystem : Enumeration

--- a/build/Parameters/SystemArchitecture.cs
+++ b/build/Parameters/SystemArchitecture.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.ComponentModel;
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.Tooling;
+using System;
+using System.ComponentModel;
 
 [TypeConverter(typeof(TypeConverter<SystemArchitecture>))]
 public class SystemArchitecture : Enumeration

--- a/templates/console.Tests/Infrastructure/ConsoleAppCancellationTokenSourceTests.cs
+++ b/templates/console.Tests/Infrastructure/ConsoleAppCancellationTokenSourceTests.cs
@@ -1,77 +1,76 @@
 using ConsoleTemplate.Infrastructure;
 
-namespace ConsoleTemplate.Tests.Infrastructure
+namespace ConsoleTemplate.Tests.Infrastructure;
+
+[TestFixture]
+public class ConsoleAppCancellationTokenSourceTests
 {
-    [TestFixture]
-    public class ConsoleAppCancellationTokenSourceTests
+    private ConsoleAppCancellationTokenSource _sut = null!; // System Under Test
+
+    [SetUp]
+    public void Setup()
     {
-        private ConsoleAppCancellationTokenSource _sut = null!; // System Under Test
+        // Create a new instance before each test
+        _sut = new ConsoleAppCancellationTokenSource();
+    }
 
-        [SetUp]
-        public void Setup()
-        {
-            // Create a new instance before each test
-            _sut = new ConsoleAppCancellationTokenSource();
-        }
+    [TearDown]
+    public void Teardown()
+    {
+        // Ensure disposal after each test
+        _sut?.Dispose();
+    }
 
-        [TearDown]
-        public void Teardown()
-        {
-            // Ensure disposal after each test
-            _sut?.Dispose();
-        }
+    [Test]
+    public void Constructor_ShouldInitializeToken_WhichIsNotCancelled()
+    {
+        // Act
+        var token = _sut.Token;
 
-        [Test]
-        public void Constructor_ShouldInitializeToken_WhichIsNotCancelled()
-        {
-            // Act
-            var token = _sut.Token;
+        // Assert
+        token.IsCancellationRequested.Should().BeFalse();
+        token.CanBeCanceled.Should().BeTrue();
+    }
 
-            // Assert
-            token.IsCancellationRequested.Should().BeFalse();
-            token.CanBeCanceled.Should().BeTrue();
-        }
+    [Test]
+    public void Dispose_ShouldCancelTheToken()
+    {
+        // Arrange
+        var token = _sut.Token;
+        token.IsCancellationRequested.Should().BeFalse(); // Pre-condition
 
-        [Test]
-        public void Dispose_ShouldCancelTheToken()
-        {
-            // Arrange
-            var token = _sut.Token;
-            token.IsCancellationRequested.Should().BeFalse(); // Pre-condition
+        // Act
+        _sut.Dispose();
 
-            // Act
-            _sut.Dispose();
+        // Assert
+        // Give a brief moment for potential background operations triggered by Dispose/Cancel
+        Thread.Sleep(50); // Small delay might be needed depending on thread scheduling
+        token.IsCancellationRequested.Should().BeTrue();
+    }
 
-            // Assert
-            // Give a brief moment for potential background operations triggered by Dispose/Cancel
-            Thread.Sleep(50); // Small delay might be needed depending on thread scheduling
-            token.IsCancellationRequested.Should().BeTrue();
-        }
+    [Test]
+    public void Dispose_CanBeCalledMultipleTimes_WithoutThrowing()
+    {
+        // Arrange
+        _sut.Dispose(); // First call
 
-        [Test]
-        public void Dispose_CanBeCalledMultipleTimes_WithoutThrowing()
-        {
-            // Arrange
-            _sut.Dispose(); // First call
+        // Act & Assert
+        Action secondDispose = () => _sut.Dispose();
+        secondDispose.Should().NotThrow();
+    }
 
-            // Act & Assert
-            Action secondDispose = () => _sut.Dispose();
-            secondDispose.Should().NotThrow();
-        }
+    [Test]
+    public void Token_ShouldReturnSameInstance()
+    {
+        // Act
+        var token1 = _sut.Token;
+        var token2 = _sut.Token;
 
-        [Test]
-        public void Token_ShouldReturnSameInstance()
-        {
-            // Act
-            var token1 = _sut.Token;
-            var token2 = _sut.Token;
-
-            // Assert
-            // CancellationToken is a struct, so we compare properties or rely on reference equality of the source
-            // For simplicity, we check CanBeCanceled as an indicator it's from the same source.
-            // A more robust check might involve reflection or modifying the SUT, but this is sufficient for basic validation.
-            token1.CanBeCanceled.Should().Be(token2.CanBeCanceled);
-            token1.IsCancellationRequested.Should().Be(token2.IsCancellationRequested);
-        }
+        // Assert
+        // CancellationToken is a struct, so we compare properties or rely on reference equality of the source
+        // For simplicity, we check CanBeCanceled as an indicator it's from the same source.
+        // A more robust check might involve reflection or modifying the SUT, but this is sufficient for basic validation.
+        token1.CanBeCanceled.Should().Be(token2.CanBeCanceled);
+        token1.IsCancellationRequested.Should().Be(token2.IsCancellationRequested);
     }
 }

--- a/templates/console/Commands/Base/CancellableAsyncCommand.cs
+++ b/templates/console/Commands/Base/CancellableAsyncCommand.cs
@@ -4,50 +4,49 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ConsoleTemplate.Commands.Base
-{
-    /// <summary>
-    /// Base class for Spectre.Console commands that support cancellation via Ctrl+C or process exit.
-    /// </summary>
-    /// <typeparam name="TSettings">The command settings type.</typeparam>
-    public abstract class CancellableAsyncCommand<TSettings> : AsyncCommand<TSettings>
-        where TSettings : CommandSettings
-    {
-        private readonly Lazy<ConsoleAppCancellationTokenSource> _cancellationTokenSource =
-            new(() => new());
+namespace ConsoleTemplate.Commands.Base;
 
-        /// <summary>
-        /// Executes the command asynchronously with cancellation support.
-        /// This method is sealed and cannot be overridden by derived classes.
-        /// Implement the cancellation-aware logic in <see cref="ExecuteAsync(CommandContext, TSettings, CancellationToken)"/>.
-        /// </summary>
-        /// <param name="context">The command context.</param>
-        /// <param name="settings">The command settings.</param>
-        /// <returns>The exit code.</returns>
-        public sealed override async Task<int> ExecuteAsync(CommandContext context, TSettings settings)
+/// <summary>
+/// Base class for Spectre.Console commands that support cancellation via Ctrl+C or process exit.
+/// </summary>
+/// <typeparam name="TSettings">The command settings type.</typeparam>
+public abstract class CancellableAsyncCommand<TSettings> : AsyncCommand<TSettings>
+    where TSettings : CommandSettings
+{
+    private readonly Lazy<ConsoleAppCancellationTokenSource> _cancellationTokenSource =
+        new(() => new());
+
+    /// <summary>
+    /// Executes the command asynchronously with cancellation support.
+    /// This method is sealed and cannot be overridden by derived classes.
+    /// Implement the cancellation-aware logic in <see cref="ExecuteAsync(CommandContext, TSettings, CancellationToken)"/>.
+    /// </summary>
+    /// <param name="context">The command context.</param>
+    /// <param name="settings">The command settings.</param>
+    /// <returns>The exit code.</returns>
+    public sealed override async Task<int> ExecuteAsync(CommandContext context, TSettings settings)
+    {
+        try
         {
-            try
+            var cancellationToken = _cancellationTokenSource.Value.Token;
+            return await ExecuteAsync(context, settings, cancellationToken);
+        }
+        finally
+        {
+            if (_cancellationTokenSource.IsValueCreated)
             {
-                var cancellationToken = _cancellationTokenSource.Value.Token;
-                return await ExecuteAsync(context, settings, cancellationToken);
-            }
-            finally
-            {
-                if (_cancellationTokenSource.IsValueCreated)
-                {
-                    _cancellationTokenSource.Value.Dispose();
-                }
+                _cancellationTokenSource.Value.Dispose();
             }
         }
-
-        /// <summary>
-        /// Executes the command asynchronously with cancellation support.
-        /// Derived classes must implement this method to provide the command logic.
-        /// </summary>
-        /// <param name="context">The command context.</param>
-        /// <param name="settings">The command settings.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>A task representing the asynchronous operation, returning the exit code.</returns>
-        public abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken);
     }
+
+    /// <summary>
+    /// Executes the command asynchronously with cancellation support.
+    /// Derived classes must implement this method to provide the command logic.
+    /// </summary>
+    /// <param name="context">The command context.</param>
+    /// <param name="settings">The command settings.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation, returning the exit code.</returns>
+    public abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken);
 }

--- a/templates/console/Commands/Base/GlobalCommandSettings.cs
+++ b/templates/console/Commands/Base/GlobalCommandSettings.cs
@@ -1,0 +1,12 @@
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace ConsoleTemplate.Commands.Base;
+
+public class GlobalCommandSettings : CommandSettings
+{
+    [CommandOption("--log-console")]
+    [Description("Enables logging to the console.")]
+    [DefaultValue(false)]
+    public bool LogToConsole { get; set; }
+}

--- a/templates/console/Commands/Example/ExampleCommand.cs
+++ b/templates/console/Commands/Example/ExampleCommand.cs
@@ -1,4 +1,6 @@
 ﻿using ConsoleTemplate.Commands.Base;
+using ConsoleTemplate.Infrastructure;
+using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.Collections.Generic;
@@ -8,31 +10,56 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace ConsoleTemplate;
-public class AddAccordingToTasksSettings : CommandSettings
+
+public class ExampleSettings : CommandSettings
 {
     [CommandOption("--limit")]
-    [Description("Quite long description.")]
+    [Description("Specifies the limit for the operation.")]
     public int? Limit { get; set; } = 4;
 
     [CommandOption("--directory")]
-    [Description("desc")]
-    public DirectoryInfo Directory { get; set; }
+    [Description("Specifies the target directory.")]
+    public DirectoryInfo? Directory { get; set; }
+
+    [CommandOption("--apikey")]
+    [Description("The API key for an external service.")]
+    [SecretSetting] // Mark this property as secret
+    public string? ApiKey { get; set; }
 }
 
-public class ExampleCommand : CancellableAsyncCommand<AddAccordingToTasksSettings>
+public class ExampleCommand : CancellableAsyncCommand<ExampleSettings>
 {
-    public override Task<int> ExecuteAsync(CommandContext context, AddAccordingToTasksSettings settings, CancellationToken cancellationToken)
+    private readonly ILogger<ExampleCommand> _logger;
+
+    public ExampleCommand(ILogger<ExampleCommand> logger)
     {
-        // Create a list of Items, apply separate styles to each
+        _logger = logger;
+    }
+
+    public override Task<int> ExecuteAsync(CommandContext context, ExampleSettings settings, CancellationToken cancellationToken)
+    {
+        // The LogInterceptor will log settings.ApiKey as [SECRET]
+        // This command-specific log now also benefits from that if settings were logged here directly,
+        // but the primary sanitization happens in the interceptor.
+        _logger.LogInformation("Processing ExampleCommand with Limit: {Limit}, Directory: {Directory}, and ApiKey (status): {ApiKeyStatus}",
+            settings.Limit,
+            settings.Directory?.FullName ?? "Not specified",
+            string.IsNullOrEmpty(settings.ApiKey) ? "Not provided" : "Provided");
+
         var rows = new List<Text>(){
             new($"Limit: {settings.Limit}", new(Color.Red, Color.Black)),
-            new($"Directory {settings.Directory}", new(Color.Green, Color.Black)),
-            new($"Leftovers {context.Remaining}", new(Color.Blue, Color.Black))
+            new($"Directory: {settings.Directory?.FullName ?? "N/A"}", new(Color.Green, Color.Black)),
+            new($"API Key: {(string.IsNullOrEmpty(settings.ApiKey) ? "Not provided" : "[SET]")}", new(Color.Yellow, Color.Black)), // Displaying status, not value
+            new($"Leftovers: {context.Remaining}", new(Color.Blue, Color.Black))
         };
 
-        // Renders each item with own style
         AnsiConsole.Write(new Rows(rows));
-        // Implement your logic here
+
+        if (settings.Directory != null && !settings.Directory.Exists)
+        {
+            _logger.LogWarning("The specified directory {DirectoryPath} does not exist.", settings.Directory.FullName);
+        }
+
         return Task.FromResult(0);
     }
 }

--- a/templates/console/ConsoleTemplate.csproj
+++ b/templates/console/ConsoleTemplate.csproj
@@ -10,7 +10,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" /> <!-- Added for appsettings.json -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" /> <!-- Added for IOptions -->
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" /> <!-- Added for IOptions -->
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageReference Include="Velopack" Version="0.0.1053" />
   </ItemGroup>

--- a/templates/console/DependencyInjection/LoggerSetup.cs
+++ b/templates/console/DependencyInjection/LoggerSetup.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+using Serilog.Events;
+using System.IO;
+
+namespace ConsoleTemplate.DependencyInjection;
+
+public static class LoggerSetup
+{
+    public static void ConfigureSerilog(IServiceCollection services, IConfiguration configuration, bool enableConsoleLogging)
+    {
+        var logDirectory = Path.Combine(Directory.GetCurrentDirectory(), "logs");
+        var logFilePath = Path.Combine(logDirectory, "app.log.json");
+
+        Directory.CreateDirectory(logDirectory);
+
+        if (File.Exists(logFilePath))
+        {
+            try
+            {
+                File.Delete(logFilePath);
+            }
+            catch (IOException ex)
+            {
+                System.Console.Error.WriteLine($"[ERROR] Could not delete existing log file '{logFilePath}': {ex.Message}");
+            }
+        }
+
+        var loggerConfiguration = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration);
+
+        if (enableConsoleLogging)
+        {
+            loggerConfiguration
+            .WriteTo.Console(
+                outputTemplate: "{Timestamp:HH:mm:ss} [{Level:u3}] {Message:lj}{NewLine}{Exception}",
+                restrictedToMinimumLevel: LogEventLevel.Information // Or another level if you want console to be less/more verbose
+            );
+        }
+
+        Log.Logger = loggerConfiguration.CreateLogger();
+        services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
+    }
+}

--- a/templates/console/DependencyInjection/TypeRegistrar.cs
+++ b/templates/console/DependencyInjection/TypeRegistrar.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using ConsoleTemplate.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 using System;
@@ -11,7 +12,7 @@ public sealed class TypeRegistrar : ITypeRegistrar
 {
     private readonly IServiceCollection _services;
 
-    public TypeRegistrar()
+    public TypeRegistrar(bool enableConsoleLogging)
     {
         _services = new ServiceCollection();
 
@@ -22,13 +23,13 @@ public sealed class TypeRegistrar : ITypeRegistrar
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
             .Build();
 
-        // --- Dependency Injection Setup ---
         _services.AddSingleton<IConfiguration>(configuration);
-        _services.Configure<ZtrTemplates.Configuration.Shared.UpdateOptions>(configuration.GetSection(nameof(UpdateOptions)));
 
-        // Register application services
+        LoggerSetup.ConfigureSerilog(_services, configuration, enableConsoleLogging); // Call the new static method
+        _services.AddSingleton<ICommandInterceptor, LogInterceptor>();
+
+        _services.Configure<UpdateOptions>(configuration.GetSection(nameof(UpdateOptions)));
         _services.AddSingleton<IUpdateService, UpdateService>();
-        // Add other services here if needed
     }
 
     public ITypeResolver Build() => new TypeResolver(_services.BuildServiceProvider());

--- a/templates/console/Infrastructure/CommandOptionExtensions.cs
+++ b/templates/console/Infrastructure/CommandOptionExtensions.cs
@@ -1,0 +1,66 @@
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel; // Required for DescriptionAttribute
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ConsoleTemplate.Infrastructure;
+
+public static class CommandOptionExtensions
+{
+    /// <summary>
+    /// Gets the first long option name (e.g., "--option") from a CommandOptionAttribute
+    /// applied to the property selected by the expression.
+    /// </summary>
+    public static string? GetLongOptionName<TSource, TProperty>(
+        Expression<Func<TSource, TProperty>> propertyLambda)
+    {
+        var propertyInfo = GetPropertyInfo(propertyLambda);
+
+        var commandOptionAttribute = propertyInfo.GetCustomAttribute<CommandOptionAttribute>();
+        if (commandOptionAttribute == null)
+        {
+            return null;
+        }
+
+        if (commandOptionAttribute.LongNames.Count > 0)
+        {
+            return $"--{commandOptionAttribute.LongNames[0]}";
+        }
+
+        if (commandOptionAttribute.ShortNames.Count > 0)
+        {
+            return $"-{commandOptionAttribute.ShortNames[0]}";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the description from a DescriptionAttribute applied to the property selected by the expression.
+    /// </summary>
+    public static string? GetDescription<TSource, TProperty>(
+        Expression<Func<TSource, TProperty>> propertyLambda)
+    {
+        var propertyInfo = GetPropertyInfo(propertyLambda);
+
+        var descriptionAttribute = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
+        return descriptionAttribute?.Description;
+    }
+
+    private static PropertyInfo GetPropertyInfo<TSource, TProperty>(
+        Expression<Func<TSource, TProperty>> propertyLambda)
+    {
+        if (propertyLambda.Body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException("Expression refers to a method, not a property.", nameof(propertyLambda));
+        }
+
+        if (memberExpression.Member is not PropertyInfo propertyInfo)
+        {
+            throw new ArgumentException("Expression refers to a field, not a property.", nameof(propertyLambda));
+        }
+
+        return propertyInfo;
+    }
+}

--- a/templates/console/Infrastructure/CustomHelpProvider.cs
+++ b/templates/console/Infrastructure/CustomHelpProvider.cs
@@ -1,0 +1,42 @@
+using ConsoleTemplate.Commands.Base;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Cli.Help;
+using Spectre.Console.Rendering;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConsoleTemplate.Infrastructure;
+
+public class CustomHelpProvider : HelpProvider
+{
+    public CustomHelpProvider(ICommandAppSettings settings)
+        : base(settings)
+    {
+    }
+
+    public override IEnumerable<IRenderable> Write(ICommandModel model, ICommandInfo? command)
+    {
+        var elements = base.Write(model, command).ToList();
+
+        elements.Add(Text.NewLine);
+        elements.Add(new Text("GLOBAL OPTIONS:", new Style(foreground: Color.Yellow, decoration: Decoration.Bold)));
+        elements.Add(Text.NewLine);
+        var grid = new Grid()
+            .AddColumn(new GridColumn().NoWrap().Padding(2, 0, 2, 0))
+            .AddColumn(new GridColumn());
+
+        var logConsoleOptionName = CommandOptionExtensions.GetLongOptionName<GlobalCommandSettings, bool>(s => s.LogToConsole);
+        var logConsoleOptionDescription = CommandOptionExtensions.GetDescription<GlobalCommandSettings, bool>(s => s.LogToConsole);
+
+        grid.AddRow(
+            new Text($"  {logConsoleOptionName ?? string.Empty}"),
+            new Text(logConsoleOptionDescription ?? string.Empty)
+        );
+
+        elements.Add(grid);
+        elements.Add(Text.NewLine);
+
+        return elements;
+    }
+}

--- a/templates/console/Infrastructure/LogInterceptor.cs
+++ b/templates/console/Infrastructure/LogInterceptor.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging;
+using Spectre.Console.Cli;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ConsoleTemplate.Infrastructure;
+
+public sealed class LogInterceptor : ICommandInterceptor
+{
+    private readonly ILogger<LogInterceptor> _logger;
+    private Stopwatch? _stopwatch;
+    private const string SecretMask = "[SECRET]";
+
+    public LogInterceptor(ILogger<LogInterceptor> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Intercept(CommandContext context, CommandSettings? settings)
+    {
+        _stopwatch = Stopwatch.StartNew();
+
+        var sanitizedSettings = SanitizeSettings(settings);
+        _logger.LogInformation("Starting execution of command: {CommandName} with settings: {@CommandSettings}",
+            context.Name,
+            sanitizedSettings);
+    }
+
+    public void InterceptResult(CommandContext context, CommandSettings settings, ref int result)
+    {
+        _stopwatch?.Stop();
+        _logger.LogInformation(
+            "Finished execution of command: {CommandName} with result code: {ResultCode}. Duration: {ElapsedDuration}.",
+            context.Name,
+            result,
+            _stopwatch?.Elapsed);
+    }
+
+    private static Dictionary<string, object?> SanitizeSettings(CommandSettings? settings)
+    {
+        if (settings == null)
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        return settings.GetType()
+            .GetProperties()
+            .Where(prop => prop.CanRead)
+            .ToDictionary(
+                prop => prop.Name,
+                prop => GetSanitizedPropertyValue(prop, settings) // Call helper method
+            );
+    }
+
+    private static object? GetSanitizedPropertyValue(PropertyInfo prop, CommandSettings? settings)
+    {
+        if (prop.GetCustomAttribute<SecretSettingAttribute>() != null)
+        {
+            return SecretMask;
+        }
+
+        var value = prop.GetValue(settings);
+        if (value is DirectoryInfo directoryInfo)
+        {
+            return directoryInfo.FullName;
+        }
+        // Add more type-specific handling here if needed in the future
+        // Example:
+        // if (value is FileInfo fileInfo)
+        // {
+        //     return fileInfo.FullName;
+        // }
+        return value;
+    }
+}

--- a/templates/console/Infrastructure/SecretSettingAttribute.cs
+++ b/templates/console/Infrastructure/SecretSettingAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ConsoleTemplate.Infrastructure;
+
+/// <summary>
+/// Indicates that a command setting property should be treated as secret
+/// and its value should be masked or omitted from logs.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+public sealed class SecretSettingAttribute : Attribute
+{
+}

--- a/templates/console/Program.cs
+++ b/templates/console/Program.cs
@@ -1,8 +1,11 @@
-﻿using Spectre.Console;
+﻿using ConsoleTemplate.Commands.Base; // Added for GlobalCommandSettings
+using ConsoleTemplate.DependencyInjection;
+using ConsoleTemplate.Infrastructure;
+using Spectre.Console;
 using Spectre.Console.Cli;
+using System.Linq;
 using System.Threading.Tasks;
 using Velopack;
-using ConsoleTemplate.DependencyInjection; // Added for TypeRegistrar namespace
 
 namespace ConsoleTemplate;
 class Program
@@ -12,8 +15,20 @@ class Program
         // Update the application
         VelopackApp.Build().Run();
 
+        // Get the log console option name dynamically
+        var logConsoleOption = CommandOptionExtensions.GetLongOptionName<GlobalCommandSettings, bool>(s => s.LogToConsole);
+        var enableConsoleLogging = false;
+        if (!string.IsNullOrEmpty(logConsoleOption))
+        {
+            enableConsoleLogging = args.Contains(logConsoleOption);
+        }
+        else
+        {
+            System.Console.Error.WriteLine("[Warning] Could not dynamically retrieve --log-console option name. Console logging may not be enabled as expected.");
+        }
+
         // Set up the command app
-        var app = new CommandApp(new TypeRegistrar());
+        var app = new CommandApp(new TypeRegistrar(enableConsoleLogging));
 
         // Register commands
         app.Configure(config =>
@@ -23,6 +38,8 @@ class Program
 #endif
 
             config.SetApplicationName("ConsoleTemplate");
+            config.SetHelpProvider(new CustomHelpProvider(config.Settings));
+
             config.AddCommand<ExampleCommand>("commandName");
             config.AddCommand<UpdateCommand>("version")
                 .WithExample("version", "--update");

--- a/templates/console/appsettings.json
+++ b/templates/console/appsettings.json
@@ -1,5 +1,27 @@
 {
   "UpdateOptions": {
     "UpdateUrl": "https://frog02-20366.wykr.es/consoletemplate/releases"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/app.log.json",
+          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog"
+        }
+      }
+    ],
+    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
+    "Properties": {
+      "Application": "ConsoleTemplate"
+    }
   }
 }


### PR DESCRIPTION
Configure Serilog for JSON file logs and readable, conditional console logs (--log-console) Mask sensitive command settings marked with [SecretSetting] attribute in all log outputs Log command execution lifecycle (start, end, duration) and sanitized parameters via LogInterceptor Display --log-console in help text using CustomHelpProvider Centralize logger configuration in LoggerSetup and integrate with DI

closes #26 