### PR TITLE
✨ feat(build): enhance update configuration and GitHub release process

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -144,7 +144,16 @@ public partial class Build : NukeBuild
             }
 
             GitTasks.Git($"tag -a {GitVersion.FullSemVer} -m \"Setting git tag on commit to '{GitVersion.FullSemVer}'\"");
-            GitTasks.Git($"push --set-upstream origin {GitVersion.FullSemVer}");
+
+            try
+            {
+                GitTasks.Git($"push origin refs/tags/{GitVersion.FullSemVer}");
+                Log.Information($"Successfully pushed tag {GitVersion.FullSemVer}.");
+            }
+            catch (ProcessException ex) when (ex.Message.Contains("already exists") || ex.Message.Contains("Updates were rejected because the tag already exists"))
+            {
+                Log.Warning($"Tag {GitVersion.FullSemVer} already exists on remote. Skipping push. Details: {ex.Message}");
+            }
         });
 
 }

--- a/templates/console/ConsoleTemplate.csproj
+++ b/templates/console/ConsoleTemplate.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" /> <!-- Added for IOptions -->
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageReference Include="Velopack" Version="0.0.1053" />
+    <PackageReference Include="Velopack" Version="0.0.1251" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refactor Build.ApplicationConfiguration.cs:
Improve GetTargetSpecificUpdateOptions for clarity and robustness Ensure useGitHubSource and fetchPrereleases consistently return boolean values Simplify logic for determining if a specific update URL was found Remove unused System import
Update templates/console/appsettings.json to default to GitHub for application updates Set UpdateUrl to the ZtrTemplates GitHub repository Enable UseGitHubSource and FetchPrereleases by default Add build/Properties/launchSettings.json with a debug profile for PublishToGitHubWithVelopack

🐛 fix(build): prevent error when pushing an already existing git tag

Modify SetGitTagAndPush in Build.cs to gracefully handle cases where a tag already exists on the remote repository, logging a warning instead of failing the build.

🏗️ build(deps): update Velopack to v0.0.1251

Update Velopack package reference in templates/console/ConsoleTemplate.csproj from 0.0.1053 to 0.0.1251.